### PR TITLE
docs: update page title to reflect portfolio site

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>AS Portfolio</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Update the HTML title tag to clearly indicate this is a portfolio site rather than the default Vite+React title.